### PR TITLE
Fix expiry date format on Merchant Page 2.0.

### DIFF
--- a/payfortfort/views/templates/hook/payment_payfortfort.tpl
+++ b/payfortfort/views/templates/hook/payment_payfortfort.tpl
@@ -20,7 +20,7 @@
     <span> / </span>
     <select id="payfort_fort_expiry_year">
       {foreach from=$years item=year}
-        <option value="{$year}">{$year}</option>
+        <option value="{$year|substr:2}">{$year}</option>
       {/foreach}
     </select>
   </p>


### PR DESCRIPTION
This change fixes an issue in Merchant Page 2.0 where the user would receive an error on checkout indicating that the `expiry_date` parameter is invalid. 

This issue is caused by the expiry date being sent to the Fort as `YYYYMM` rather than the correct format which is `YYMM`. For example, 12/2019 was formatted as 201912 rather than 1912 as required by Fort API.

Fixed by applying `substr` on `$year` to remove the first two digits. For example, 2019 -> 19. This truncation is applied only to the `value` portion and not the text visible to the user. As in, the user clicks on the value "2021" for example and the code will handle it as "21". Which formats the `expiry_date` parameter correctly.

Pending:
- [x] Code review
- [x] QA testing